### PR TITLE
Update pyscf2qwalk.py

### DIFF
--- a/pyscf2qwalk.py
+++ b/pyscf2qwalk.py
@@ -7,10 +7,11 @@ import json
 ###########################################################
 def find_label(sph_label):
   data = sph_label.split( )
-  if(data[2][1]!='g'):
-    return data[2][1:]
+  label = data[2].lstrip('0123456789')
+  if(label[0]!='g'):
+    return label
   elif(len(data)==3):
-    return 'gm'+data[2][3]
+    return 'gm'+label[2]
   else:
     return 'gp'+data[3] 
 


### PR DESCRIPTION
I noticed when trying to convert calculation that used an uncontracted basis that had 10 or more primitives in a given basis type, that the print_orb_coeff would crash when looking up the aosym. This is because the find_label function looked at the second character in the string, which for 10s would be 0 instead of s, which was being used to define the basis label. This change fixes that, by using lstrip to strip all leading integers in the sph_label